### PR TITLE
Fix issue where multitouch would spawn another joystick

### DIFF
--- a/addons/versatile-mobile-joystick/joystick.gd
+++ b/addons/versatile-mobile-joystick/joystick.gd
@@ -170,7 +170,7 @@ func _is_inside_touch_detector(pos: Vector2) -> bool:
 func _input(event: InputEvent) -> void:
 	if event is InputEventScreenTouch:
 		# Touch start
-		if event.pressed:
+		if event.pressed and not being_touched:
 			if _is_inside_touch_detector(event.position):
 				joystick_touch_index = event.index
 				being_touched = true


### PR DESCRIPTION
hello I noticed that in a multitouch environment, starting another touch would overwrite the last joystick, making the joystick_touch_index always be the latest one, effectively preventing any multi touch scenarios

I propose the change to only create the joystick if not currently being touched.